### PR TITLE
Bind rdoc to version rbs transitive works on jruby

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem "rubocop-rake"
 
 gem "rubocop-rspec"
 
-gem "rdoc"
+# TODO: allow rdoc >=8 when transitive dep 'rbs' supports jruby.
+gem "rdoc", "<8"
 
 gem "simplecov"


### PR DESCRIPTION
https://github.com/ruby/rdoc/issues/1746 documents this.

This limitation is expected to be short term and affects only dev.