### PR TITLE
Revert "Bind rdoc to version rbs transitive works on jruby"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,6 @@ gem "rubocop-rake"
 
 gem "rubocop-rspec"
 
-# TODO: allow rdoc >=8 when transitive dep 'rbs' supports jruby.
-gem "rdoc", "<8"
+gem "rdoc"
 
 gem "simplecov"


### PR DESCRIPTION
Reverts colindean/fillertext#105

:warning: Do not merge until rbs >=4.1.0 is released with jruby support. :warning: 

rbs versions: https://rubygems.org/gems/rbs/versions

Upstream tracking in rdoc, which has rbs as transitive: https://github.com/ruby/rdoc/issues/1746